### PR TITLE
change binaries to dsc plus tests

### DIFF
--- a/src/clients/Providers/BridgeClientProvider.ts
+++ b/src/clients/Providers/BridgeClientProvider.ts
@@ -28,9 +28,7 @@ export class BridgeClientProvider implements IClientProvider {
     public Type: ClientType = ClientType.Bridge;
 
     public getExecutableFilePath(): string {
-        const binariesName = this._expectedBridgeVersion != null &&
-                            (this._expectedBridgeVersion <= `1.0.20210708.15` ||
-                            this._expectedBridgeVersion > `1.0.20210818.0`) ? `dsc` : `bridge`;
+        const binariesName = `dsc`;
 
         switch (process.platform) {
         case `win32`:

--- a/src/tests/suites/BridgeClientProvider-Test.ts
+++ b/src/tests/suites/BridgeClientProvider-Test.ts
@@ -1,0 +1,14 @@
+import * as assert from 'assert';
+import { BinariesVersionClient } from '../../clients/BinariesVersionClient';
+import { CommandRunner } from '../../clients/CommandRunner';
+import { BridgeClientProvider } from '../../clients/Providers/BridgeClientProvider';
+import { IClientProvider } from '../../clients/Providers/IClientProvider';
+suite('BridgeClientProviderTest', () => {
+    test('should return binaries name as dsc always', async () => {
+        const expectedCLIVersion = '1.0.20220816.2';
+        const binariesVersionClient: BinariesVersionClient = new BinariesVersionClient(expectedCLIVersion, null);
+        const bridgeClientProvider: IClientProvider = new BridgeClientProvider(binariesVersionClient, expectedCLIVersion, new CommandRunner(null), null);
+        const binariesName = bridgeClientProvider.getExecutableFilePath();
+        assert.strictEqual(binariesName, `dsc`);
+    });
+});

--- a/src/tests/suites/ExpectedCLIVersion-Test.ts
+++ b/src/tests/suites/ExpectedCLIVersion-Test.ts
@@ -10,7 +10,7 @@ suite(`Expected CLI Test`, () => {
     const expectedCLIVersion: string = await versionUtility.VersionUtility.getExpectedCliVersionAsync(packageJsonContent);
     assert.strictEqual(expectedCLIVersion, `1.0.20220816.2`);
   });
-  test('should return expectedCLIVersion when BRIDGE_BUILD_PATH is set', async () => {
+  test('should return null as expectedCLIVersion when BRIDGE_BUILD_PATH is set', async () => {
     let env = process.env;
     env.BRIDGE_BUILD_PATH = 'somepath';
     const packageJsonContent = JSON.parse(`{
@@ -21,7 +21,7 @@ suite(`Expected CLI Test`, () => {
     const expectedCLIVersion: string = await versionUtility.VersionUtility.getExpectedCliVersionAsync(packageJsonContent);
     assert.strictEqual(expectedCLIVersion, null);
   });
-  test('should return BRIDGE_CLI_VERSION as expectedCLIVersion when it is set', async () => {
+  test('should return BRIDGE_CLI_VERSION as expectedCLIVersion when BRIDGE_CLI_VERSION is set', async () => {
     let env = process.env;
     env.BRIDGE_BUILD_PATH = null;
     env.BRIDGE_CLI_VERSION = '1.0.20220816.X';

--- a/src/tests/suites/ExpectedCLIVersion-Test.ts
+++ b/src/tests/suites/ExpectedCLIVersion-Test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import * as versionUtility  from '../../utility/VersionUtility';
+import * as versionUtility from '../../utility/VersionUtility';
 suite(`Expected CLI Test`, () => {
   test(`should return expectedCLIVersion`, async () => {
     const packageJsonContent = JSON.parse(`{
@@ -9,5 +9,28 @@ suite(`Expected CLI Test`, () => {
     }`);
     const expectedCLIVersion: string = await versionUtility.VersionUtility.getExpectedCliVersionAsync(packageJsonContent);
     assert.strictEqual(expectedCLIVersion, `1.0.20220816.2`);
+  });
+  test('should return expectedCLIVersion when BRIDGE_BUILD_PATH is set', async () => {
+    let env = process.env;
+    env.BRIDGE_BUILD_PATH = 'somepath';
+    const packageJsonContent = JSON.parse(`{
+      "extensionMetadata": {
+        "expectedCLIVersion": "1.0.20220816.2"
+      }
+    }`);
+    const expectedCLIVersion: string = await versionUtility.VersionUtility.getExpectedCliVersionAsync(packageJsonContent);
+    assert.strictEqual(expectedCLIVersion, null);
+  });
+  test('should return BRIDGE_CLI_VERSION as expectedCLIVersion when it is set', async () => {
+    let env = process.env;
+    env.BRIDGE_BUILD_PATH = null;
+    env.BRIDGE_CLI_VERSION = '1.0.20220816.X';
+    const packageJsonContent = JSON.parse(`{
+      "extensionMetadata": {
+        "expectedCLIVersion": "1.0.20220816.2"
+      }
+    }`);
+    const expectedCLIVersion: string = await versionUtility.VersionUtility.getExpectedCliVersionAsync(packageJsonContent);
+    assert.strictEqual(expectedCLIVersion, '1.0.20220816.X');
   });
 });

--- a/src/utility/VersionUtility.ts
+++ b/src/utility/VersionUtility.ts
@@ -52,7 +52,7 @@ export class VersionUtility {
         //  3. If bridge build path is not set to null, then expected CLI version will be null
         const packageJsonVersion: string = packageJsonContent[`extensionMetadata`][`expectedCLIVersion`];
         const expectedCLIVersion = process.env.BRIDGE_CLI_VERSION != null ? process.env.BRIDGE_CLI_VERSION :
-            (process.env.BRIDGE_BUILD_PATH === null ? packageJsonVersion : null);
+            (process.env.BRIDGE_BUILD_PATH != null || process.env.BRIDGE_BUILD_PATH != undefined ? null : packageJsonVersion);
 
         return expectedCLIVersion;
     }


### PR DESCRIPTION
This PR is to add test cases and correct the condition in the version utility.ts file and change the binaries name to dsc always. we can get this reviewed from Dan as well. 